### PR TITLE
Always use Time.now as the end_time when requesting metrics

### DIFF
--- a/fluent-plugin-azuremonitormetrics.gemspec
+++ b/fluent-plugin-azuremonitormetrics.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = "fluent-plugin-azuremonitormetrics"
-  gem.version       = "0.0.4"
+  gem.version       = "0.0.5"
   gem.authors       = ["Ilana Kantorov"]
   gem.email         = ["ilanak@microsoft.com"]
   gem.description   = %q{Input plugin for Azure Monitor Metrics.}


### PR DESCRIPTION
Fixes issue 5. Always use `Time.now` as the `end_time` when requesting metrics.
This fix is required so that the plugin doesn't fall behind in time when HTTP requests to Azure take some time.

Sample output:
```
2019-08-01 19:45:38 +0000 [debug]: #0 start time: 2019-08-01 19:44:37 UTC, end time: 2019-08-01 19:45:38 +0000, effective timespan: 60.384603589
2019-08-01 19:46:38 +0000 [debug]: #0 start time: 2019-08-01 19:45:38 UTC, end time: 2019-08-01 19:46:38 +0000, effective timespan: 60.336988971
2019-08-01 19:47:38 +0000 [debug]: #0 start time: 2019-08-01 19:46:38 UTC, end time: 2019-08-01 19:47:38 +0000, effective timespan: 60.389274681
2019-08-01 19:48:39 +0000 [debug]: #0 start time: 2019-08-01 19:47:38 UTC, end time: 2019-08-01 19:48:39 +0000, effective timespan: 60.291426713
2019-08-01 19:49:39 +0000 [debug]: #0 start time: 2019-08-01 19:48:39 UTC, end time: 2019-08-01 19:49:39 +0000, effective timespan: 60.182220697
2019-08-01 19:50:39 +0000 [debug]: #0 start time: 2019-08-01 19:49:39 UTC, end time: 2019-08-01 19:50:39 +0000, effective timespan: 60.233241417
2019-08-01 19:51:39 +0000 [debug]: #0 start time: 2019-08-01 19:50:39 UTC, end time: 2019-08-01 19:51:39 +0000, effective timespan: 60.176336143
2019-08-01 19:52:40 +0000 [debug]: #0 start time: 2019-08-01 19:51:39 UTC, end time: 2019-08-01 19:52:40 +0000, effective timespan: 60.357913299
```